### PR TITLE
fix for cf_get_ext to use the last '.' for extensions, and a test file.

### DIFF
--- a/cute_files.h
+++ b/cute_files.h
@@ -225,10 +225,10 @@ static int cf_safe_strcpy_internal(char* dst, const char* src, int n, int max, c
 
 const char* cf_get_ext(cf_file_t* file)
 {
-	char* period = file->name;
-	char c;
-	while ((c = *period++)) if (c == '.') break;
-	if (c) cf_safe_strcpy(file->ext, period, 0, CUTE_FILES_MAX_EXT);
+	char* name = file->name;
+	char* period = NULL;
+	while (*name++) if (*name == '.') period = name;
+	if (period) cf_safe_strcpy(file->ext, period, 0, CUTE_FILES_MAX_EXT);
 	else file->ext[0] = 0;
 	return file->ext;
 }


### PR DESCRIPTION
#107

I ran examples_cute_files/main.c with no issue, the new `examples_cute_files/a/2.subext.txt` was detected as having a `.txt` extension.