### PR TITLE
cute_time: mark prev value as static in POSIX implementation

### DIFF
--- a/cute_time.h
+++ b/cute_time.h
@@ -174,7 +174,7 @@ void cs_record(ct_timer_t* timer);
 	float ct_time()
 	{
 		static int first = 1;
-		struct timespec prev;
+		static struct timespec prev;
 		
 		if (first)
 		{


### PR DESCRIPTION
Note: I didn't test that it doesn't work before the change. And I didn't test it after the change either. Just common sense.