### PR TITLE
Fix cf_match_ext failing to match on Windows

### DIFF
--- a/cute_files.h
+++ b/cute_files.h
@@ -261,7 +261,6 @@ void cf_traverse(const char* path, cf_callback_t* cb, void* udata)
 
 int cf_match_ext(cf_file_t* file, const char* ext)
 {
-	if (*ext == '.') ++ext;
 	return !strcmp(file->ext, ext);
 }
 


### PR DESCRIPTION
Fixes it on Windows.
I haven't tested on other OSs. This could possibly break them, if they don't keep the period in `ct_file_t.ext`