### PR TITLE
Added names to unnamed cute_c2 API structs

### DIFF
--- a/cute_c2.h
+++ b/cute_c2.h
@@ -122,7 +122,7 @@
 
 
 	Contributors
-	
+
 		Plastburk         1.01 - const pointers pull request
 		mmozeiko          1.02 - 3 compile bugfixes
 		felipefs          1.02 - 3 compile bugfixes
@@ -143,21 +143,21 @@
 #define C2_MAX_POLYGON_VERTS 8
 
 // 2d vector
-typedef struct
+typedef struct c2v
 {
 	float x;
 	float y;
 } c2v;
 
 // 2d rotation composed of cos/sin pair
-typedef struct
+typedef struct c2r
 {
 	float c;
 	float s;
 } c2r;
 
 // 2d rotation matrix
-typedef struct
+typedef struct c2m
 {
 	c2v x;
 	c2v y;
@@ -170,40 +170,40 @@ typedef struct
 // a c2x pointer (like c2PolytoPoly), these pointers can be NULL, which represents
 // an identity transformation and assumes the verts inside of c2Poly are already
 // in world space.
-typedef struct
+typedef struct c2x
 {
 	c2v p;
 	c2r r;
 } c2x;
 
 // 2d halfspace (aka plane, aka line)
-typedef struct
+typedef struct c2h
 {
 	c2v n;   // normal, normalized
 	float d; // distance to origin from plane, or ax + by = d
 } c2h;
 
-typedef struct
+typedef struct c2Circle
 {
 	c2v p;
 	float r;
 } c2Circle;
 
-typedef struct
+typedef struct c2AABB
 {
 	c2v min;
 	c2v max;
 } c2AABB;
 
 // a capsule is defined as a line segment (from a to b) and radius r
-typedef struct
+typedef struct c2Capsule
 {
 	c2v a;
 	c2v b;
 	float r;
 } c2Capsule;
 
-typedef struct
+typedef struct c2Poly
 {
 	int count;
 	c2v verts[C2_MAX_POLYGON_VERTS];
@@ -215,14 +215,14 @@ typedef struct
 // ray direction (c2Ray::d). It is highly recommended to normalize the
 // ray direction and use t to specify a distance. Please see this link
 // for an in-depth explanation: https://github.com/RandyGaul/cute_headers/issues/30
-typedef struct
+typedef struct c2Ray
 {
 	c2v p;   // position
 	c2v d;   // direction (normalized)
 	float t; // distance along d from position p to find endpoint of ray
 } c2Ray;
 
-typedef struct
+typedef struct c2Raycast
 {
 	float t; // time of impact
 	c2v n;   // normal of surface at impact (unit length)
@@ -240,7 +240,7 @@ typedef struct
 // of simulations that cache information over multiple game-ticks, of which are
 // associated to the collision of specific features. An example implementation
 // is in the qu3e 3D physics engine library: https://github.com/RandyGaul/qu3e
-typedef struct
+typedef struct c2Manifold
 {
 	int count;
 	float depths[2];
@@ -308,7 +308,7 @@ typedef enum
 
 // This struct is only for advanced usage of the c2GJK function. See comments inside of the
 // c2GJK function for more details.
-typedef struct
+typedef struct c2GJKCache
 {
 	float metric;
 	int count;


### PR DESCRIPTION
I added names to the API structs because I need them in my use case. The reason I need them is because the LuaJIT FFI doesn't parse the typedefs as the actual names of the structures, despite the typedef being parsed and usable in most cases. However, when I run `tostring(c2AABB())`, I get `"cdata<struct 14572>"` as my return value. Initially, I tried to work around this without editing the cute_c2 header, but I can't fully fix all use cases unless the FFI-generated type information is correct. Having the struct defined as a number is unacceptable for me because the number changes as I add new C libraries.