### PR TITLE
fix bug when file extension is longer than 32 characters

### DIFF
--- a/cute_files.h
+++ b/cute_files.h
@@ -73,7 +73,6 @@
 
 #define CUTE_FILES_MAX_PATH 1024
 #define CUTE_FILES_MAX_FILENAME 256
-#define CUTE_FILES_MAX_EXT 32
 
 struct cf_file_t;
 struct cf_dir_t;
@@ -137,7 +136,7 @@ void cf_do_unit_tests();
 	{
 		char path[CUTE_FILES_MAX_PATH];
 		char name[CUTE_FILES_MAX_FILENAME];
-		char ext[CUTE_FILES_MAX_EXT];
+		char * ext;
 		int is_dir;
 		int is_reg;
 		size_t size;
@@ -167,7 +166,7 @@ void cf_do_unit_tests();
 	{
 		char path[CUTE_FILES_MAX_PATH];
 		char name[CUTE_FILES_MAX_FILENAME];
-		char ext[CUTE_FILES_MAX_EXT];
+		char * ext;
 		int is_dir;
 		int is_reg;
 		int size;
@@ -225,11 +224,15 @@ static int cf_safe_strcpy_internal(char* dst, const char* src, int n, int max, c
 
 const char* cf_get_ext(cf_file_t* file)
 {
+	char c;
 	char* name = file->name;
-	char* period = NULL;
-	while (*name++) if (*name == '.') period = name;
-	if (period) cf_safe_strcpy(file->ext, period, 0, CUTE_FILES_MAX_EXT);
-	else file->ext[0] = 0;
+	file->ext = file->name;
+	while (c = *name) {
+		++name;
+		if (c == '.')
+			file->ext = name;
+	}
+	if(file->ext == file->name) file->ext = name;
 	return file->ext;
 }
 


### PR DESCRIPTION
I had trouble on my local file system because I had files with file extensions longer than 32 characters. The file struct was using a fixed size char array just for the file extension.

I didn't saw the use of that when we could have instead a char pointer pointing right at the beginning of the extension inside our filename array removing the extension length limit of 32 altogether.  

The only way how this change could cause any problems would be when someone would change the extension after read (like making it all uppercase) and expect it not changing the full filename. 



I saw that the same exact function is also in cute_filewatch.h, I haven't touched this one. 