### PR TITLE
Fix MSVC Error C4996 in #181, Update for Tiled 1.3.3 JSON format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,8 @@
 # Executables
 example
 tests
+
+# vim
+*.swp
+*.swo
+*.orig

--- a/cute_tiled.h
+++ b/cute_tiled.h
@@ -2123,6 +2123,13 @@ static int cute_tiled_dispatch_map_internal(cute_tiled_map_internal_t* m)
 
  	switch (h)
 	{
+	case 5549108793316760247U: // compressionlevel
+	{
+		int compressionlevel;
+		cute_tiled_read_int(m, &compressionlevel);
+		CUTE_TILED_CHECK(compressionlevel == -1, "Compression is not yet supported.");
+	}	break;
+
 	case 17465100621023921744U: // backgroundcolor
 		cute_tiled_expect(m, '"');
 		cute_tiled_read_hex_int(m, &m->map.backgroundcolor);

--- a/cute_tiled.h
+++ b/cute_tiled.h
@@ -1286,7 +1286,7 @@ static int cute_tiled_try(cute_tiled_map_internal_t* m, char expect)
 
 #define cute_tiled_expect(m, expect) \
 	do { \
-		CUTE_TILED_CHECK(cute_tiled_next(m) == expect, "Found unexpected token (is this a valid JSON file?)."); \
+		CUTE_TILED_CHECK(cute_tiled_next(m) == (expect), "Found unexpected token (is this a valid JSON file?)."); \
 	} while (0)
 
 char cute_tiled_parse_char(char c)

--- a/cute_tiled.h
+++ b/cute_tiled.h
@@ -1305,10 +1305,42 @@ char cute_tiled_parse_char(char c)
 	}
 }
 
+static int cute_tiled_skip_object_internal(cute_tiled_map_internal_t* m)
+{
+	int depth = 1;
+	cute_tiled_expect(m, '{');
+
+	while (depth) {
+		char c = cute_tiled_next(m);
+		switch(c)
+		{
+		case '{':
+			depth += 1;
+			break;
+		case '}':
+			depth -= 1;
+			break;
+		default:
+			break;
+		}
+	}
+
+	return 1;
+
+cute_tiled_err:
+	return 0;
+}
+
+#define cute_tiled_skip_object(m) \
+	do { \
+		CUTE_TILED_FAIL_IF(!cute_tiled_skip_object_internal(m)); \
+	} while (0)
+
 static int cute_tiled_read_string_internal(cute_tiled_map_internal_t* m)
 {
 	int count = 0;
 	int done = 0;
+
 	cute_tiled_expect(m, '"');
 
 	while (!done)
@@ -2129,6 +2161,10 @@ static int cute_tiled_dispatch_map_internal(cute_tiled_map_internal_t* m)
 		cute_tiled_read_int(m, &compressionlevel);
 		CUTE_TILED_CHECK(compressionlevel == -1, "Compression is not yet supported.");
 	}	break;
+
+	case 13648382824248632287U: // editorsettings
+		cute_tiled_skip_object(m);
+		break;
 
 	case 17465100621023921744U: // backgroundcolor
 		cute_tiled_expect(m, '"');

--- a/cute_tiled.h
+++ b/cute_tiled.h
@@ -515,7 +515,7 @@ struct strpool_embedded_t
 #ifndef STRPOOL_EMBEDDED_STRNICMP
     #ifdef _WIN32
         #include <string.h>
-        #define STRPOOL_EMBEDDED_STRNICMP( s1, s2, len ) ( strnicmp( s1, s2, len ) )
+        #define STRPOOL_EMBEDDED_STRNICMP( s1, s2, len ) ( _strnicmp( s1, s2, len ) )
     #else
         #include <string.h>
         #define STRPOOL_EMBEDDED_STRNICMP( s1, s2, len ) ( strncasecmp( s1, s2, len ) )        

--- a/cute_tiled.h
+++ b/cute_tiled.h
@@ -1343,7 +1343,6 @@ static int cute_tiled_read_string_internal(cute_tiled_map_internal_t* m)
 {
 	int count = 0;
 	int done = 0;
-
 	cute_tiled_expect(m, '"');
 
 	while (!done)

--- a/cute_tiled.h
+++ b/cute_tiled.h
@@ -1312,14 +1312,17 @@ static int cute_tiled_skip_object_internal(cute_tiled_map_internal_t* m)
 
 	while (depth) {
 		char c = cute_tiled_next(m);
+
 		switch(c)
 		{
 		case '{':
 			depth += 1;
 			break;
+
 		case '}':
 			depth -= 1;
 			break;
+
 		default:
 			break;
 		}

--- a/cute_tiled.h
+++ b/cute_tiled.h
@@ -94,6 +94,7 @@
 
 // Read this in the event of errors
 extern const char* cute_tiled_error_reason;
+extern int cute_tiled_error_cline;
 
 typedef struct cute_tiled_map_t cute_tiled_map_t;
 
@@ -1143,6 +1144,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #endif
 
 const char* cute_tiled_error_reason;
+int cute_tiled_error_cline;
 
 #ifdef CUTE_TILED_DEFAULT_WARNING
 	#include <stdio.h>
@@ -1244,7 +1246,7 @@ cute_tiled_map_t* cute_tiled_load_map_from_file(const char* path, void* mem_ctx)
 	return map;
 }
 
-#define CUTE_TILED_CHECK(X, Y) do { if (!(X)) { cute_tiled_error_reason = Y; goto cute_tiled_err; } } while (0)
+#define CUTE_TILED_CHECK(X, Y) do { if (!(X)) { cute_tiled_error_reason = Y; cute_tiled_error_cline = __LINE__; goto cute_tiled_err; } } while (0)
 #define CUTE_TILED_FAIL_IF(X) do { if (X) { goto cute_tiled_err; } } while (0)
 
 static int cute_tiled_isspace(char c)
@@ -1284,7 +1286,7 @@ static int cute_tiled_try(cute_tiled_map_internal_t* m, char expect)
 
 #define cute_tiled_expect(m, expect) \
 	do { \
-		CUTE_TILED_CHECK(cute_tiled_next(m) == (expect), "Found unexpected token (is this a valid JSON file?)."); \
+		CUTE_TILED_CHECK(cute_tiled_next(m) == expect, "Found unexpected token (is this a valid JSON file?)."); \
 	} while (0)
 
 char cute_tiled_parse_char(char c)


### PR DESCRIPTION
Error	C4996	'strnicmp': The POSIX name for this item is deprecated. Instead,
use the ISO C and C++ conformant name: _strnicmp.