### PR TITLE
Fix macro expanding issue in #178

### DIFF
--- a/cute_tiled.h
+++ b/cute_tiled.h
@@ -1284,7 +1284,7 @@ static int cute_tiled_try(cute_tiled_map_internal_t* m, char expect)
 
 #define cute_tiled_expect(m, expect) \
 	do { \
-		CUTE_TILED_CHECK(cute_tiled_next(m) == expect, "Found unexpected token (is this a valid JSON file?)."); \
+		CUTE_TILED_CHECK(cute_tiled_next(m) == (expect), "Found unexpected token (is this a valid JSON file?)."); \
 	} while (0)
 
 char cute_tiled_parse_char(char c)


### PR DESCRIPTION
The macro `cute_tiled_expect` does not wrap the argument `expect` with brackets, leading to operator precedence issues if the argument contains, for example, a ternary operator.

This fixes these issues by replacing `expect` in the macro with `(expect)`.