### PR TITLE
cute_sound.h: Add cs_get_playing

### DIFF
--- a/cute_sound.h
+++ b/cute_sound.h
@@ -136,6 +136,11 @@
 		The same def can be used to play as many sounds as desired (even simultaneously)
 		as long as the context playing sound pool is large enough.
 
+		You can work with some low-level functionality by iterating through the linked list
+		ctx->playing, which can be accessed by calling cs_get_playing(ctx). If you spawned a
+		thread via cs_spawn_mix_thread, remember to call cs_lock before you work with
+		cs_get_playing and call cs_unlock afterwards so sound can play again.
+
 
 	Low-level API
 
@@ -363,6 +368,12 @@ void cs_spawn_mix_thread(cs_context_t* ctx);
 // A recommended sleep time is a little less than 1/2 your predicted 1/FPS.
 // 60 fps is 16 ms, so about 1-5 should work well in most cases.
 void cs_thread_sleep_delay(cs_context_t* ctx, int milliseconds);
+
+// Lock the thread before working with some of the lower-level stuff.
+void cs_lock(cs_context_t* ctx);
+
+// Unlock the thread after you've done that stuff.
+void cs_unlock(cs_context_t* ctx);
 
 // Call this manually, once per game tick recommended, if you haven't ever
 // called cs_spawn_mix_thread. Otherwise the thread will call cs_mix itself.
@@ -1272,12 +1283,12 @@ static DWORD WINAPI cs_ctx_thread(LPVOID lpParameter)
 	return 0;
 }
 
-static void cs_lock(cs_context_t* ctx)
+void cs_lock(cs_context_t* ctx)
 {
 	if (ctx->separate_thread) EnterCriticalSection(&ctx->critical_section);
 }
 
-static void cs_unlock(cs_context_t* ctx)
+void cs_unlock(cs_context_t* ctx)
 {
 	if (ctx->separate_thread) LeaveCriticalSection(&ctx->critical_section);
 }
@@ -1472,12 +1483,12 @@ static void* cs_ctx_thread(void* udata)
 	return 0;
 }
 
-static void cs_lock(cs_context_t* ctx)
+void cs_lock(cs_context_t* ctx)
 {
 	if (ctx->separate_thread) pthread_mutex_lock(&ctx->mutex);
 }
 
-static void cs_unlock(cs_context_t* ctx)
+void cs_unlock(cs_context_t* ctx)
 {
 	if (ctx->separate_thread) pthread_mutex_unlock(&ctx->mutex);
 }
@@ -1736,12 +1747,12 @@ int cs_ctx_thread(void* udata)
 	return 0;
 }
 
-static void cs_lock(cs_context_t* ctx)
+void cs_lock(cs_context_t* ctx)
 {
 	if (ctx->separate_thread) pthread_mutex_lock(&ctx->mutex);
 }
 
-static void cs_unlock(cs_context_t* ctx)
+void cs_unlock(cs_context_t* ctx)
 {
 	if (ctx->separate_thread) pthread_mutex_unlock(&ctx->mutex);
 }
@@ -1945,12 +1956,12 @@ int cs_ctx_thread(void* udata)
 	return 0;
 }
 
-static void cs_lock(cs_context_t* ctx)
+void cs_lock(cs_context_t* ctx)
 {
 	if (ctx->separate_thread) SDL_LockMutex(ctx->mutex);
 }
 
-static void cs_unlock(cs_context_t* ctx)
+void cs_unlock(cs_context_t* ctx)
 {
 	if (ctx->separate_thread) SDL_UnlockMutex(ctx->mutex);
 }

--- a/cute_sound.h
+++ b/cute_sound.h
@@ -398,6 +398,9 @@ void cs_set_volume(cs_playing_sound_t* sound, float volume_left, float volume_ri
 // void cs_set_delay(cs_playing_sound_t* sound, float delay, int samples_per_second)
 void cs_set_delay(cs_context_t* ctx, cs_playing_sound_t* sound, float delay_in_seconds);
 
+// Return the linked list ctx->playing
+cs_playing_sound_t* cs_get_playing(cs_context_t* ctx);
+
 // Portable sleep function. Do not call this with milliseconds > 999.
 void cs_sleep(int milliseconds);
 
@@ -406,10 +409,6 @@ cs_playing_sound_t cs_make_playing_sound(cs_loaded_sound_t* loaded);
 int cs_insert_sound(cs_context_t* ctx, cs_playing_sound_t* sound); // returns 1 if sound was successfully inserted, 0 otherwise
 
 // HIGH-LEVEL API
-
-// This def struct is just used to pass parameters to `cs_play_sound`.
-// Be careful since `loaded` points to a `cs_loaded_sound_t` struct, so make
-// sure the `cs_loaded_sound_t` struct persists in memory!
 typedef struct cs_play_sound_def_t
 {
 	int paused;
@@ -1098,7 +1097,7 @@ cs_loaded_sound_t cs_load_ogg(const char* path)
 {
 	int length;
 	void* memory = cs_read_file_to_memory(path, &length, NULL);
-	cs_loaded_sound_t sound = { 0 };
+	cs_loaded_sound_t sound = { 0, 0, 0, 0, { NULL, NULL } };
 	cs_read_mem_ogg(memory, length, &sound);
 	CUTE_SOUND_FREE(memory, NULL);
 
@@ -2032,6 +2031,13 @@ void cs_spawn_mix_thread(cs_context_t* ctx)
 }
 
 #endif // CUTE_SOUND_PLATFORM == CUTE_SOUND_***
+
+// Platform-agnostic functions that access cs_context_t members go here.
+
+cs_playing_sound_t* cs_get_playing(cs_context_t* ctx)
+{
+	return ctx->playing;
+}
 
 #if CUTE_SOUND_PLATFORM == CUTE_SOUND_SDL || CUTE_SOUND_PLATFORM == CUTE_SOUND_APPLE
 

--- a/cute_sound.h
+++ b/cute_sound.h
@@ -409,6 +409,10 @@ cs_playing_sound_t cs_make_playing_sound(cs_loaded_sound_t* loaded);
 int cs_insert_sound(cs_context_t* ctx, cs_playing_sound_t* sound); // returns 1 if sound was successfully inserted, 0 otherwise
 
 // HIGH-LEVEL API
+
+// This def struct is just used to pass parameters to `cs_play_sound`.
+// Be careful since `loaded` points to a `cs_loaded_sound_t` struct, so make
+// sure the `cs_loaded_sound_t` struct persists in memory!
 typedef struct cs_play_sound_def_t
 {
 	int paused;


### PR DESCRIPTION
Since members of `cs_context_t` are private, I added a getter for `playing`. This is needed in my game, where several sounds are adjusted globally at arbitrary times.

Also fixed a C++ warning with stb_vorbis.