### PR TITLE
cute_tiled.h - Skip editorsettings field when parsing external tilesets

### DIFF
--- a/cute_tiled.h
+++ b/cute_tiled.h
@@ -2263,6 +2263,10 @@ cute_tiled_tileset_t* cute_tiled_tileset(cute_tiled_map_internal_t* m)
 			cute_tiled_read_int(m, &tileset->columns);
 			break;
 
+		case 13648382824248632287U: // editorsettings
+			cute_tiled_skip_object(m);
+			break;
+
 		case 13956389100366699181U: // firstgid
 			cute_tiled_read_int(m, &tileset->firstgid);
 			break;


### PR DESCRIPTION
Skip editorsettings field when parsing an external tileset so we don't completely fail when we attempt the load.