### PR TITLE
Fixed double freeing of slices

### DIFF
--- a/cute_aseprite.h
+++ b/cute_aseprite.h
@@ -1195,7 +1195,6 @@ void cute_aseprite_free(ase_t* ase)
 	for (int i = 0; i < ase->palette.entry_count; ++i) {
 		CUTE_ASEPRITE_FREE((void*)ase->palette.entries[i].color_name, ase->mem_ctx);
 	}
-	if (ase->slice_count) CUTE_ASEPRITE_FREE((void*)ase->slices[0].name, ase->mem_ctx);
 	CUTE_ASEPRITE_FREE(ase->color_profile.icc_profile_data, ase->mem_ctx);
 	CUTE_ASEPRITE_FREE(ase->frames, ase->mem_ctx);
 	CUTE_ASEPRITE_FREE(ase, ase->mem_ctx);


### PR DESCRIPTION
Hello!
First of all, thanks so much for these amazing libraries, love em!

I've been playing around with cute_aseprite, and it worked great until I turned my attention to slices.
No matter what I did, I would get a segfault, if the aseprite file had any slices in it. 
After a little debugging session, I figured out that the slices were freed twice, I've removed the second `free()` call and now it works just fine!

I wanted to save everyone else using this amazing library from doubting themselves for a few hours, so I wanted to merge this fix into the official repo :) 

Thanks, Egor. 