### PR TITLE
Compression level 0 in tiled specification also means no compression

### DIFF
--- a/cute_tiled.h
+++ b/cute_tiled.h
@@ -2409,7 +2409,7 @@ static int cute_tiled_dispatch_map_internal(cute_tiled_map_internal_t* m)
 	{
 		int compressionlevel;
 		cute_tiled_read_int(m, &compressionlevel);
-		CUTE_TILED_CHECK(compressionlevel == -1, "Compression is not yet supported.");
+		CUTE_TILED_CHECK(compressionlevel == -1 || compressionlevel == 0, "Compression is not yet supported.");
 	}	break;
 
 	case 13648382824248632287U: // editorsettings


### PR DESCRIPTION
Hello again :)
Continuing my path down the headers, this time spotted a little quirk/?change? with tiled-exported map files,
the `compressionLevel` is now set to `0`, if you export without any compression (`CVS`).

The library would freak out because it isn't `-1`, so I've added the expected `0` value along side `-1`.
Thanks, Egor.