### PR TITLE
Fix a bug in cf_traverse: The return value of cf_read_file must be ch…

### DIFF
--- a/cute_files.h
+++ b/cute_files.h
@@ -241,7 +241,12 @@ void cf_traverse(const char* path, cf_callback_t* cb, void* udata)
 	while (dir.has_next)
 	{
 		cf_file_t file;
-		cf_read_file(&dir, &file);
+		int res = cf_read_file(&dir, &file);
+
+		if (res == 0) {
+			cf_dir_next(&dir);
+			continue;
+		}
 
 		if (file.is_dir && file.name[0] != '.')
 		{


### PR DESCRIPTION
…ecked.

If it failed, the non-existent file must be skipped.