### PR TITLE
Fixed two compile errors with cl.exe

### DIFF
--- a/cute_aseprite.h
+++ b/cute_aseprite.h
@@ -107,6 +107,7 @@ void cute_aseprite_free(ase_t* aseprite);
 
 #include <stdint.h>
 
+typedef struct ase_color_t ase_color_t;
 typedef struct ase_frame_t ase_frame_t;
 typedef struct ase_layer_t ase_layer_t;
 typedef struct ase_cel_t ase_cel_t;
@@ -832,7 +833,7 @@ static ase_color_t s_blend(ase_color_t src, ase_color_t dst, uint8_t opacity)
 		g = dst.g + (src.g - dst.g) * src.a / a;
 		b = dst.b + (src.b - dst.b) * src.a / a;
 	}
-	return { (uint8_t)r, (uint8_t)g, (uint8_t)b, (uint8_t)a };
+	return (ase_color_t) { (uint8_t)r, (uint8_t)g, (uint8_t)b, (uint8_t)a };
 }
 
 static int s_min(int a, int b)


### PR DESCRIPTION
cute_aseprite.h was throwing two errors when compiling on windows with cl.exe, these two updates fix those issues.