### PR TITLE
Skip 'ff' in hex values, causing issues with mingw

### DIFF
--- a/cute_tiled.h
+++ b/cute_tiled.h
@@ -1522,8 +1522,13 @@ static int cute_tiled_read_hex_int_internal(cute_tiled_map_internal_t* m, int* o
 	switch (cute_tiled_peak(m))
 	{
 	case '#':
+	{
+		char c = cute_tiled_next(m);
+		c = cute_tiled_next(m);
+		CUTE_TILED_CHECK(c == 'f', "Expected 'f' while parsing a hex number.");
 		cute_tiled_next(m);
-		break;
+		CUTE_TILED_CHECK(c == 'f', "Expected 'f' while parsing a hex number.");
+	}	break;
 
 	case '0':
 	{


### PR DESCRIPTION
I was parsing color properties with no issue on linux, but when I ran
it on windows (mingw), the color value was wrong. I pin pointed the issue being
strtol returning -1 when parsing the hex string. The implementation must
work differently, skipping the first two unused 'ff' in the hex string
fixes it.
