### PR TITLE
png: Update CUTE_PNG_FILIO to be STDIO

### DIFF
--- a/cute_png.h
+++ b/cute_png.h
@@ -211,9 +211,9 @@ struct cp_atlas_image_t
 	#define CUTE_PNG_ASSERT assert
 #endif
 
-#if !defined(CUTE_PNG_FILEIO)
+#if !defined(CUTE_PNG_STDIO)
 	#include <stdio.h>  // fopen, fclose, etc.
-	#define CUTE_PNG_FILEIO
+	#define CUTE_PNG_STDIO
 	#define CUTE_PNG_SEEK_SET SEEK_SET
 	#define CUTE_PNG_SEEK_END SEEK_END
 	#define CUTE_PNG_FILE FILE


### PR DESCRIPTION
Having the definition include the name of the file it's allowing overwriting may make a bit more sense than `FILEIO`.