### PR TITLE
aseprite: Update CUTE_ASEPRITE_FILEIO to be STDIO

### DIFF
--- a/cute_aseprite.h
+++ b/cute_aseprite.h
@@ -344,9 +344,9 @@ struct ase_t
 	#define CUTE_ASEPRITE_ASSERT assert
 #endif
 
-#if !defined(CUTE_ASEPRITE_FILEIO)
+#if !defined(CUTE_ASEPRITE_STDIO)
 	#include <stdio.h> // fopen
-	#define CUTE_ASEPRITE_FILEIO
+	#define CUTE_ASEPRITE_STDIO
 	#define CUTE_ASEPRITE_SEEK_SET SEEK_SET
 	#define CUTE_ASEPRITE_SEEK_END SEEK_END
 	#define CUTE_ASEPRITE_FILE FILE


### PR DESCRIPTION
Having the `CUTE_ASEPRITE_FILEIO` definition match the name of the header file it is re-implementing may make a bit more sense.