### PR TITLE
Convert <Windows.h> inclusions to lowercase

### DIFF
--- a/cute_files.h
+++ b/cute_files.h
@@ -131,7 +131,7 @@ void cf_do_unit_tests();
 #if !defined _CRT_SECURE_NO_WARNINGS
 #define _CRT_SECURE_NO_WARNINGS
 #endif
-#include <Windows.h>
+#include <windows.h>
 
 	struct cf_file_t
 	{

--- a/cute_filewatch.h
+++ b/cute_filewatch.h
@@ -1132,7 +1132,7 @@ void cf_do_unit_tests();
 #if !defined _CRT_SECURE_NO_WARNINGS
 #define _CRT_SECURE_NO_WARNINGS
 #endif
-#include <Windows.h>
+#include <windows.h>
 
 	struct cf_file_t
 	{

--- a/cute_sync.h
+++ b/cute_sync.h
@@ -326,7 +326,7 @@ struct cute_rw_lock_t
 		// 0x0400=Windows NT 4.0, 0x0500=Windows 2000, 0x0501=Windows XP, 0x0502=Windows Server 2003, 0x0600=Windows Vista,
 		// 0x0601=Windows 7, 0x0602=Windows 8, 0x0603=Windows 8.1, 0x0A00=Windows 10
 	#endif
-	#include <Windows.h>
+	#include <windows.h>
 #elif defined(CUTE_SYNC_POSIX)
 	#include <pthread.h>
 	#include <semaphore.h>
@@ -356,7 +356,7 @@ struct cute_rw_lock_t
 #if !defined(CUTE_SYNC_YIELD)
 	#ifdef CUTE_SYNC_WINDOWS
 		#define WIN32_LEAN_AND_MEAN
-		#include <Windows.h> // winnt
+		#include <windows.h> // winnt
 		#define CUTE_SYNC_YIELD YieldProcessor
 	#elif defined(CUTE_SYNC_POSIX)
 		#include <sched.h>

--- a/examples_cute_files/main.c
+++ b/examples_cute_files/main.c
@@ -1,5 +1,5 @@
 #ifdef _WIN32
-#include <Windows.h>
+#include <windows.h>
 #endif
 
 #define CUTE_FILES_IMPLEMENTATION


### PR DESCRIPTION
I was having issues when trying to cross-compile Windows binaries on Linux using Mingw-w64 with the `cute_files.h` header. It looks like Mingw needs the `Windows.h` header to be all lowercase in order to successfully include it.

Most of the relevant inclusions across the `cute_headers` code are already lowercase, this change just converts the rest.