### PR TITLE
If layer opacity does not have a valid value, use full opacity.

### DIFF
--- a/cute_aseprite.h
+++ b/cute_aseprite.h
@@ -908,10 +908,7 @@ ase_t* cute_aseprite_load_from_memory(const void* memory, int size, void* mem_ct
 		CUTE_ASEPRITE_ASSERT(bpp == 1);
 		ase->mode = ASE_MODE_INDEXED;
 	}
-	if (s_read_uint32(s) & 1) {
-		// Layer opacity has valid value.
-		// Ok... So?
-	}
+	uint32_t valid_layer_opacity = s_read_uint32(s) & 1;
 	int speed = s_read_uint16(s);
 	s_skip(s, sizeof(uint32_t) * 2); // Spec says skip these bytes, as they're zero'd.
 	ase->transparent_palette_entry_index = s_read_uint8(s);
@@ -963,6 +960,7 @@ ase_t* cute_aseprite_load_from_memory(const void* memory, int size, void* mem_ct
 				int blend_mode = (int)s_read_uint16(s);
 				if (blend_mode) CUTE_ASEPRITE_WARNING("Unknown blend mode encountered.");
 				layer->opacity = s_read_uint8(s) / 255.0f;
+				if (!valid_layer_opacity) layer->opacity = 1.0f;
 				s_skip(s, 3); // For future use (set to zero).
 				layer->name = s_read_string(s);
 				last_udata = &layer->udata;


### PR DESCRIPTION
I have an older ASE file (circa 2014), which in Aseprite, shows a layer at full opacity.  But as written to disk, the "layer opacity has valid value" flag is set to false (0) and the layer opacity is set to zero.  The current cute_aseprite code ignores the "Layer opacity has valid value" flag.  This patch changes the behavior to match Aseprite.

Note that if I re-save the 2014 file in a current version of Aseprite (1.2.25 or 1.3 beta), the "layer opacity has valid value" flag gets set to 1 and the opacity gets set to 255.