### PR TITLE
aseprite: Fix compilation errors

### DIFF
--- a/cute_aseprite.h
+++ b/cute_aseprite.h
@@ -883,7 +883,10 @@ static ase_color_t s_color(ase_t* ase, void* src, int index)
 		CUTE_ASEPRITE_ASSERT(ase->mode == ASE_MODE_INDEXED);
 		uint8_t palette_index = ((uint8_t*)src)[index];
 		if (palette_index == ase->transparent_palette_entry_index) {
-			result = { 0, 0, 0, 0 };
+			result.r = 0;
+			result.g = 0;
+			result.b = 0;
+			result.a = 0;
 		} else {
 			result = ase->palette.entries[palette_index].color;
 		}
@@ -1162,7 +1165,7 @@ ase_t* cute_aseprite_load_from_memory(const void* memory, int size, void* mem_ct
 			}
 
 			uint32_t size_read = (uint32_t)(s->in - chunk_start);
-			CUTE_ASSERT(size_read == chunk_size);
+			CUTE_ASEPRITE_ASSERT(size_read == chunk_size);
 		}
 	}
 


### PR DESCRIPTION
This fixes up two compilation errors I was running into...
``` bash
In file included from main.c:4:
../cute_aseprite.h: In function ‘s_color’:
../cute_aseprite.h:886:13: error: expected expression before ‘{’ token
  886 |    result = { 0, 0, 0, 0 };
      |             ^
../cute_aseprite.h: In function ‘cute_aseprite_load_from_memory’:
../cute_aseprite.h:1165:4: error: implicit declaration of function ‘CUTE_ASSERT’ [-Werror=implicit-function-declaration]
 1165 |    CUTE_ASSERT(size_read == chunk_size);
      |    ^~~~~~~~~~~
cc1: all warnings being treated as errors
make: *** [Makefile:2: example] Error 1
```