### PR TITLE
Fixed minor typo: string.h should be strings.h

### DIFF
--- a/cute_tiled.h
+++ b/cute_tiled.h
@@ -579,10 +579,10 @@ struct strpool_embedded_t
 
 #ifndef STRPOOL_EMBEDDED_STRNICMP
     #ifdef _WIN32
-        #include <string.h>
+        #include <strings.h>
         #define STRPOOL_EMBEDDED_STRNICMP( s1, s2, len ) ( _strnicmp( s1, s2, len ) )
     #else
-        #include <string.h>
+        #include <strings.h>
         #define STRPOOL_EMBEDDED_STRNICMP( s1, s2, len ) ( strncasecmp( s1, s2, len ) )
     #endif
 #endif


### PR DESCRIPTION
Minor typo: string.h should be strings.h