### PR TITLE
 Revert erroneously changing string.h in favor of strings.h in STRPOOL_EMBEDDED_STRNICMP define

### DIFF
--- a/cute_tiled.h
+++ b/cute_tiled.h
@@ -579,7 +579,7 @@ struct strpool_embedded_t
 
 #ifndef STRPOOL_EMBEDDED_STRNICMP
     #ifdef _WIN32
-        #include <strings.h>
+        #include <string.h>
         #define STRPOOL_EMBEDDED_STRNICMP( s1, s2, len ) ( _strnicmp( s1, s2, len ) )
     #else
         #include <strings.h>

--- a/cute_tiled.h
+++ b/cute_tiled.h
@@ -579,10 +579,10 @@ struct strpool_embedded_t
 
 #ifndef STRPOOL_EMBEDDED_STRNICMP
     #ifdef _WIN32
-        #include <string.h>
+        #include <strings.h>
         #define STRPOOL_EMBEDDED_STRNICMP( s1, s2, len ) ( _strnicmp( s1, s2, len ) )
     #else
-        #include <string.h>
+        #include <strings.h>
         #define STRPOOL_EMBEDDED_STRNICMP( s1, s2, len ) ( strncasecmp( s1, s2, len ) )
     #endif
 #endif


### PR DESCRIPTION
I changed a Windows include without checking first to see it was the right one. It turns out _strnicmp is located in "string.h" not "strings.h" as I had assumed.