### PR TITLE
Split up the CUTE_*_STDIO defines

### DIFF
--- a/cute_aseprite.h
+++ b/cute_aseprite.h
@@ -347,16 +347,43 @@ struct ase_t
 	#define CUTE_ASEPRITE_ASSERT assert
 #endif
 
-#if !defined(CUTE_ASEPRITE_STDIO)
-	#include <stdio.h> // fopen
-	#define CUTE_ASEPRITE_STDIO
+#if !defined(CUTE_ASEPRITE_SEEK_SET)
+	#include <stdio.h> // SEEK_SET
 	#define CUTE_ASEPRITE_SEEK_SET SEEK_SET
+#endif
+
+#if !defined(CUTE_ASEPRITE_SEEK_END)
+	#include <stdio.h> // SEEK_END
 	#define CUTE_ASEPRITE_SEEK_END SEEK_END
+#endif
+
+#if !defined(CUTE_ASEPRITE_FILE)
+	#include <stdio.h> // FILE
 	#define CUTE_ASEPRITE_FILE FILE
+#endif
+
+#if !defined(CUTE_ASEPRITE_FOPEN)
+	#include <stdio.h> // fopen
 	#define CUTE_ASEPRITE_FOPEN fopen
+#endif
+
+#if !defined(CUTE_ASEPRITE_FSEEK)
+	#include <stdio.h> // fseek
 	#define CUTE_ASEPRITE_FSEEK fseek
+#endif
+
+#if !defined(CUTE_ASEPRITE_FREAD)
+	#include <stdio.h> // fread
 	#define CUTE_ASEPRITE_FREAD fread
+#endif
+
+#if !defined(CUTE_ASEPRITE_FTELL)
+	#include <stdio.h> // ftell
 	#define CUTE_ASEPRITE_FTELL ftell
+#endif
+
+#if !defined(CUTE_ASEPRITE_FCLOSE)
+	#include <stdio.h> // fclose
 	#define CUTE_ASEPRITE_FCLOSE fclose
 #endif
 

--- a/cute_png.h
+++ b/cute_png.h
@@ -211,17 +211,48 @@ struct cp_atlas_image_t
 	#define CUTE_PNG_ASSERT assert
 #endif
 
-#if !defined(CUTE_PNG_STDIO)
-	#include <stdio.h>  // fopen, fclose, etc.
-	#define CUTE_PNG_STDIO
+#if !defined(CUTE_PNG_SEEK_SET)
+	#include <stdio.h> // SEEK_SET
 	#define CUTE_PNG_SEEK_SET SEEK_SET
+#endif
+
+#if !defined(CUTE_PNG_SEEK_END)
+	#include <stdio.h> // SEEK_END
 	#define CUTE_PNG_SEEK_END SEEK_END
+#endif
+
+#if !defined(CUTE_PNG_FILE)
+	#include <stdio.h> // FILE
 	#define CUTE_PNG_FILE FILE
+#endif
+
+#if !defined(CUTE_PNG_FOPEN)
+	#include <stdio.h> // fopen
 	#define CUTE_PNG_FOPEN fopen
+#endif
+
+#if !defined(CUTE_PNG_FSEEK)
+	#include <stdio.h> // fseek
 	#define CUTE_PNG_FSEEK fseek
+#endif
+
+#if !defined(CUTE_PNG_FREAD)
+	#include <stdio.h> // fread
 	#define CUTE_PNG_FREAD fread
+#endif
+
+#if !defined(CUTE_PNG_FTELL)
+	#include <stdio.h> // ftell
 	#define CUTE_PNG_FTELL ftell
+#endif
+
+#if !defined(CUTE_PNG_FCLOSE)
+	#include <stdio.h> // fclose
 	#define CUTE_PNG_FCLOSE fclose
+#endif
+
+#if !defined(CUTE_PNG_FERROR)
+	#include <stdio.h> // ferror
 	#define CUTE_PNG_FERROR ferror
 #endif
 

--- a/cute_sound.h
+++ b/cute_sound.h
@@ -128,7 +128,13 @@
 			CUTE_SOUND_MEMCPY
 			CUTE_SOUND_MEMSET
 			CUTE_SOUND_MEMCMP
+			CUTE_SOUND_SEEK_SET
+			CUTE_SOUND_SEEK_END
+			CUTE_SOUND_FILE
 			CUTE_SOUND_FOPEN
+			CUTE_SOUND_FSEEK
+			CUTE_SOUND_FREAD
+			CUTE_SOUND_FTELL
 			CUTE_SOUND_FCLOSE
 
 
@@ -446,13 +452,43 @@ cs_error_t cs_add_plugin(const cs_plugin_interface_t* plugin);
 #	define CUTE_SOUND_MEMCMP memcmp
 #endif
 
-#ifndef CUTE_SOUND_FOPEN
-#	include <stdio.h>
+#ifndef(CUTE_SOUND_SEEK_SET)
+#	include <stdio.h> // SEEK_SET
+#	define CUTE_SOUND_SEEK_SET SEEK_SET
+#endif
+
+#ifndef(CUTE_SOUND_SEEK_END)
+#	include <stdio.h> // SEEK_END
+#	define CUTE_SOUND_SEEK_END SEEK_END
+#endif
+
+#ifndef(CUTE_SOUND_FILE)
+#	include <stdio.h> // FILE
+#	define CUTE_SOUND_FILE FILE
+#endif
+
+#ifndef(CUTE_SOUND_FOPEN)
+#	include <stdio.h> // fopen
 #	define CUTE_SOUND_FOPEN fopen
 #endif
 
-#ifndef CUTE_SOUND_FCLOSE
-#	include <stdio.h>
+#ifndef(CUTE_SOUND_FSEEK)
+#	include <stdio.h> // fseek
+#	define CUTE_SOUND_FSEEK fseek
+#endif
+
+#ifndef(CUTE_SOUND_FREAD)
+#	include <stdio.h> // fread
+#	define CUTE_SOUND_FREAD fread
+#endif
+
+#ifndef(CUTE_SOUND_FTELL)
+#	include <stdio.h> // ftell
+#	define CUTE_SOUND_FTELL ftell
+#endif
+
+#ifndef(CUTE_SOUND_FCLOSE)
+#	include <stdio.h> // fclose
 #	define CUTE_SOUND_FCLOSE fclose
 #endif
 
@@ -2322,16 +2358,16 @@ static void* cs_read_file_to_memory(const char* path, int* size, void* mem_ctx)
 {
 	(void)mem_ctx;
 	void* data = 0;
-	FILE* fp = fopen(path, "rb");
+	CUTE_SOUND_FILE* fp = CUTE_SOUND_FOPEN(path, "rb");
 	int sizeNum = 0;
 
 	if (fp) {
-		fseek(fp, 0, SEEK_END);
-		sizeNum = (int)ftell(fp);
-		fseek(fp, 0, SEEK_SET);
+		CUTE_SOUND_FSEEK(fp, 0, CUTE_SOUND_SEEK_END);
+		sizeNum = (int)CUTE_SOUND_FTELL(fp);
+		CUTE_SOUND_FSEEK(fp, 0, CUTE_SOUND_SEEK_SET);
 		data = CUTE_SOUND_ALLOC(sizeNum, mem_ctx);
-		(void)(fread(data, sizeNum, 1, fp) + 1);
-		fclose(fp);
+		(void)(CUTE_SOUND_FREAD(data, sizeNum, 1, fp) + 1);
+		CUTE_SOUND_FCLOSE(fp);
 	}
 
 	if (size) *size = sizeNum;

--- a/cute_tiled.h
+++ b/cute_tiled.h
@@ -1228,22 +1228,48 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 	#endif
 #endif
 
-#if defined(CUTE_TILED_SNPRINTF) || defined(CUTE_TILED_STDIO)
-	#include <stdio.h>  // snprintf, fopen, fclose, etc.
-#endif
-
 #if !defined(CUTE_TILED_SNPRINTF)
+	#include <stdio.h> // snprintf
 	#define CUTE_TILED_SNPRINTF snprintf
 #endif
 
-#if !defined(CUTE_TILED_STDIO)
+#if !defined(CUTE_TILED_SEEK_SET)
+	#include <stdio.h> // SEEK_SET
 	#define CUTE_TILED_SEEK_SET SEEK_SET
+#endif
+
+#if !defined(CUTE_TILED_SEEK_END)
+	#include <stdio.h> // SEEK_END
 	#define CUTE_TILED_SEEK_END SEEK_END
+#endif
+
+#if !defined(CUTE_TILED_FILE)
+	#include <stdio.h> // FILE
 	#define CUTE_TILED_FILE FILE
+#endif
+
+#if !defined(CUTE_TILED_FOPEN)
+	#include <stdio.h> // fopen
 	#define CUTE_TILED_FOPEN fopen
+#endif
+
+#if !defined(CUTE_TILED_FSEEK)
+	#include <stdio.h> // fseek
 	#define CUTE_TILED_FSEEK fseek
+#endif
+
+#if !defined(CUTE_TILED_FREAD)
+	#include <stdio.h> // fread
 	#define CUTE_TILED_FREAD fread
+#endif
+
+#if !defined(CUTE_TILED_FTELL)
+	#include <stdio.h> // ftell
 	#define CUTE_TILED_FTELL ftell
+#endif
+
+#if !defined(CUTE_TILED_FCLOSE)
+	#include <stdio.h> // fclose
 	#define CUTE_TILED_FCLOSE fclose
 #endif
 


### PR DESCRIPTION
This adopts the pattern introduced in [cute_sound.h](https://github.com/RandyGaul/cute_headers/blob/master/cute_sound.h#L449) to split the individual `CUTE_*_STDIO` defines into their individual defines.

It gives quite a bit more control over how the defines are leveraged.