### PR TITLE
aseprite: Fix compiler warnings

### DIFF
--- a/cute_aseprite.h
+++ b/cute_aseprite.h
@@ -528,7 +528,7 @@ static uint32_t s_build(deflate_t* s, uint32_t* tree, uint8_t* lens, int sym_cou
 		first[n] = first[n - 1] + counts[n - 1];
 	}
 
-	for (int i = 0; i < sym_count; ++i)
+	for (uint32_t i = 0; i < (uint32_t)sym_count; ++i)
 	{
 		uint8_t len = lens[i];
 
@@ -556,7 +556,8 @@ static int s_stored(deflate_t* s)
 	// read LEN and NLEN, should complement each other
 	uint16_t LEN = (uint16_t)s_read_bits(s, 16);
 	uint16_t NLEN = (uint16_t)s_read_bits(s, 16);
-	CUTE_ASEPRITE_CHECK(LEN == (uint16_t)(~NLEN), "Failed to find LEN and NLEN as complements within stored (uncompressed) stream.");
+	uint16_t TILDE_NLEN = ~NLEN;
+	CUTE_ASEPRITE_CHECK(LEN == TILDE_NLEN, "Failed to find LEN and NLEN as complements within stored (uncompressed) stream.");
 	CUTE_ASEPRITE_CHECK(s->bits_left / 8 <= (int)LEN, "Stored block extends beyond end of input stream.");
 	p = s_ptr(s);
 	CUTE_ASEPRITE_MEMCPY(s->out, p, LEN);
@@ -683,7 +684,7 @@ static int s_inflate(const void* in, int in_bytes, void* out, int out_bytes, voi
 	s->bits_left = in_bytes * 8;
 
 	// s->words is the in-pointer rounded up to a multiple of 4
-	int first_bytes = (int)((((size_t)in + 3) & ~3) - (size_t)in);
+	int first_bytes = (int)((((size_t)in + 3) & (size_t)(~3)) - (size_t)in);
 	s->words = (uint32_t*)((char*)in + first_bytes);
 	s->word_count = (in_bytes - first_bytes) / 4;
 	int last_bytes = ((in_bytes - first_bytes) & 3);
@@ -797,8 +798,8 @@ static uint64_t s_read_uint64(ase_state_t* s)
 }
 #endif
 
-static int16_t s_read_int16(ase_state_t* s) { return (int16_t)s_read_uint16(s); }
-static int16_t s_read_int32(ase_state_t* s) { return (int32_t)s_read_uint32(s); }
+#define s_read_int16(s) (int16_t)s_read_uint16(s)
+#define s_read_int32(s) (int32_t)s_read_uint32(s)
 
 #ifdef CUTE_ASPRITE_S_READ_BYTES
 // s_read_bytes() is not currently used.


### PR DESCRIPTION
This fixes up a few compiler warnings...

``` bash
cute_aseprite.h: In function ‘s_build’:
cute_aseprite.h:540:69: warning: conversion to ‘uint32_t’ {aka ‘unsigned int’} from ‘int’ may change the sign of the result [-Wsign-conversion]
  540 |                         tree[slot] = (code << (32 - (uint32_t)len)) | (i << 4) | len;
      |                                                                     ^
cute_aseprite.h: In function ‘s_stored’:
cute_aseprite.h:559:33: warning: comparison of promoted bitwise complement of an unsigned value with unsigned [-Wsign-compare]
  559 |         CUTE_ASEPRITE_CHECK(LEN == (uint16_t)(~NLEN), "Failed to find LEN and NLEN as complements within stored (uncompressed) stream.");
      |                                 ^~
cute_aseprite.h:406:46: note: in definition of macro ‘CUTE_ASEPRITE_CHECK’
  406 | #define CUTE_ASEPRITE_CHECK(X, Y) do { if (!(X)) { s_error_reason = Y; CUTE_ASEPRITE_FAIL(); } } while (0)
      |                                              ^
cute_aseprite.h: In function ‘s_inflate’:
cute_aseprite.h:686:51: warning: unsigned conversion from ‘int’ to ‘long unsigned int’ changes value from ‘-4’ to ‘18446744073709551612’ [-Wsign-conversion]
  686 |         int first_bytes = (int)((((size_t)in + 3) & ~3) - (size_t)in);
      |                                                   ^
cute_aseprite.h: In function ‘s_read_int32’:
cute_aseprite.h:801:54: warning: conversion from ‘int’ to ‘int16_t’ {aka ‘short int’} may change value [-Wconversion]
  801 | static int16_t s_read_int32(ase_state_t* s) { return (int32_t)s_read_uint32(s); }
      |                                                      ^~~~~~~~~~~~~~~~~~~~~~~~~
```