### PR TITLE
Fix ignored attributes selectany, always_inline

### DIFF
--- a/cute_math.h
+++ b/cute_math.h
@@ -48,8 +48,8 @@
 #	define CUTE_MATH_RESTRICT __restrict
 #else
 // Just assume a g++-like compiler.
-#	define CUTE_MATH_INLINE __attribute__((always_inline))
-#	define CUTE_MATH_SELECTANY extern const __attribute__((selectany))
+#	define CUTE_MATH_INLINE __attribute__((always_inline)) inline
+#	define CUTE_MATH_SELECTANY extern const __attribute__((weak))
 #	define CUTE_MATH_RESTRICT __restrict__
 #endif
 


### PR DESCRIPTION
* Fix GCC ignored attribute `always_inline`; [1]
* Fix GCC attribute `selectany` ignored
  - Attribute only available on Windows target[2]
  - Fix with alternative [3]

[1]: https://stackoverflow.com/q/32432596/183120
[2]: https://gcc.gnu.org/onlinedocs/gcc-4.2.4/gcc/Variable-Attributes.html
[3]: https://stackoverflow.com/q/4826612/183120

Fixes #321.