### PR TITLE
[cute_net] fix compiling with clang on windows

### DIFF
--- a/cute_net.h
+++ b/cute_net.h
@@ -672,7 +672,7 @@ extern "C" {
 #define _hydro_attr_warn_unused_result_ _hydro_attr_((warn_unused_result))
 #define _hydro_attr_weak_ _hydro_attr_((weak))
 
-#if defined(__INTEL_COMPILER) || defined(_MSC_VER)
+#if defined(__INTEL_COMPILER) || (defined(_MSC_VER) && !defined(__clang__))
 #define _hydro_attr_aligned_(X) __declspec(align(X))
 #elif defined(__clang__) || defined(__GNUC__)
 #define _hydro_attr_aligned_(X) _hydro_attr_((aligned(X)))


### PR DESCRIPTION
When compiling with clang on windows MSC_VER is defined and can conflict, leading to an unclear error (below). The real cause is the alignment macro which has accidentally used the MSVC compatible one instead of the clang compatible one.

```c++
cute_net.h(1663,24): error: default initialization of an object of const type 'const uint32_t [24]'
 static const uint32_t coeffs[24] __declspec(align(16)) = {
                       ^
cute_net.h(1663,34): error: expected ';' after top level declarator
 static const uint32_t coeffs[24] __declspec(align(16)) = {
                                 ^
                                 ;
cute_net.h(1663,57): error: expected unqualified-id
 static const uint32_t coeffs[24] __declspec(align(16)) = {
```