### PR TITLE
cute_png: check for image size int overflow on load

### DIFF
--- a/cute_png.h
+++ b/cute_png.h
@@ -1108,6 +1108,7 @@ cp_image_t cp_load_png_mem(const void* png_data, int png_length)
 	h = cp_make32(ihdr + 4);
 	CUTE_PNG_CHECK(w >= 1, "invalid IHDR chunk found, image width was less than 1");
 	CUTE_PNG_CHECK(h >= 1, "invalid IHDR chunk found, image height was less than 1");
+        CUTE_PNG_CHECK(w * h * sizeof(cp_pixel_t) < INT_MAX, "image too large");
 	pix_bytes = w * h * sizeof(cp_pixel_t);
 	img.w = w - 1;
 	img.h = h;
@@ -1326,6 +1327,7 @@ cp_indexed_image_t cp_load_indexed_png_mem(const void *png_data, int png_length)
 	// +1 for filter byte (which is dumb! just stick this at file header...)
 	w = cp_make32(ihdr) + 1;
 	h = cp_make32(ihdr + 4);
+        CUTE_PNG_CHECK(w * h * sizeof(uint8_t) < INT_MAX, "image too large");
 	pix_bytes = w * h * sizeof(uint8_t);
 	img.w = w - 1;
 	img.h = h;


### PR DESCRIPTION
Integer overflow appears to be the cause of #335. This patch fixes the test case and https://github.com/dbohdan/hicolor/issues/2.