### PR TITLE
cute_png: only #include alloca.h on Linux

### DIFF
--- a/cute_png.h
+++ b/cute_png.h
@@ -230,7 +230,7 @@ struct cp_atlas_image_t
 
 	#ifdef _WIN32
 		#include <malloc.h>
-	#else
+	#elif defined(__linux__)
 		#include <alloca.h>
 	#endif
 #endif


### PR DESCRIPTION
Right now cute_png does not compile out-of-the-box on NetBSD and OpenBSD because they don't have `alloca.h`. I think `alloca.h` is a Linux (GNU and musl libc) quirk. With this patch cute_png seems to work perfectly (my project's 20+ tests pass) on Net- and OpenBSD. (It likely works on FreeBSD, although I have not tested. And maybe on macOS, too?)