### PR TITLE
Fix use of memcpy across cute_png, cute_sound, and cute_spritebatch

### DIFF
--- a/cute_png.h
+++ b/cute_png.h
@@ -1637,7 +1637,7 @@ cp_image_t cp_make_atlas(int atlas_width, int atlas_height, const cp_image_t* pn
 			int new_capacity = atlas_node_capacity * 2;
 			cp_atlas_node_t* new_nodes = (cp_atlas_node_t*)CUTE_PNG_ALLOC(sizeof(cp_atlas_node_t) * new_capacity);
 			CUTE_PNG_CHECK(new_nodes, "out of mem");
-			memcpy(new_nodes, nodes, sizeof(cp_atlas_node_t) * sp);
+			CUTE_PNG_MEMCPY(new_nodes, nodes, sizeof(cp_atlas_node_t) * sp);
 			CUTE_PNG_FREE(nodes);
 			// best_fit became a dangling pointer, so relocate it
 			best_fit = new_nodes + (best_fit - nodes);

--- a/cute_sound.h
+++ b/cute_sound.h
@@ -981,7 +981,7 @@ void* hashtable_insert( hashtable_t* table, HASHTABLE_U64 key, void const* item 
 
 
     void* dest_item = (void*)( ( (uintptr_t) table->items_data ) + table->count * table->item_size );
-    memcpy( dest_item, item, (HASHTABLE_SIZE_T) table->item_size );
+    HASHTABLE_MEMCPY( dest_item, item, (HASHTABLE_SIZE_T) table->item_size );
     table->items_key[ table->count ] = key;
     table->items_slot[ table->count ] = slot;
     ++table->count;
@@ -2030,13 +2030,13 @@ static void cs_dsound_memcpy_to_driver(int16_t* samples, int byte_to_lock, int b
 	unsigned running_index = s_ctx->running_index;
 	INT16* sample1 = (INT16*)region1;
 	DWORD sample1_count = size1 / s_ctx->bps;
-	memcpy(sample1, samples, sample1_count * sizeof(INT16) * 2);
+	CUTE_SOUND_MEMCPY(sample1, samples, sample1_count * sizeof(INT16) * 2);
 	samples += sample1_count * 2;
 	running_index += sample1_count;
 
 	INT16* sample2 = (INT16*)region2;
 	DWORD sample2_count = size2 / s_ctx->bps;
-	memcpy(sample2, samples, sample2_count * sizeof(INT16) * 2);
+	CUTE_SOUND_MEMCPY(sample2, samples, sample2_count * sizeof(INT16) * 2);
 	samples += sample2_count * 2;
 	running_index += sample2_count;
 

--- a/cute_spritebatch.h
+++ b/cute_spritebatch.h
@@ -787,7 +787,7 @@ void* hashtable_insert( hashtable_t* table, HASHTABLE_U64 key, void const* item 
 
 
     void* dest_item = (void*)( ( (uintptr_t) table->items_data ) + table->count * table->item_size );
-    memcpy( dest_item, item, (HASHTABLE_SIZE_T) table->item_size );
+    HASHTABLE_MEMCPY( dest_item, item, (HASHTABLE_SIZE_T) table->item_size );
     table->items_key[ table->count ] = key;
     table->items_slot[ table->count ] = slot;
     ++table->count;
@@ -1779,7 +1779,7 @@ void spritebatch_make_atlas(spritebatch_t* sb, spritebatch_internal_atlas_t* atl
 			int new_capacity = atlas_node_capacity * 2;
 			spritebatch_internal_atlas_node_t* new_nodes = (spritebatch_internal_atlas_node_t*)SPRITEBATCH_MALLOC(sizeof(spritebatch_internal_atlas_node_t) * new_capacity, mem_ctx);
 			SPRITEBATCH_CHECK(new_nodes, "out of mem");
-			memcpy(new_nodes, nodes, sizeof(spritebatch_internal_atlas_node_t) * sp);
+			SPRITEBATCH_MEMCPY(new_nodes, nodes, sizeof(spritebatch_internal_atlas_node_t) * sp);
 			SPRITEBATCH_FREE(nodes, mem_ctx);
 			nodes = new_nodes;
 			atlas_node_capacity = new_capacity;


### PR DESCRIPTION
This updates the references to memcpy across the three includes to make use of their associated MEMCPY macros
