### PR TITLE
cute_sound: Add CUTE_SOUND_PLATFORM_* Defines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 # Executables
 example
 tests
+examples_cute_sound/sdl_demo/sdl_demo
 
 # vim
 *.swp

--- a/examples_cute_sound/sdl_demo/Makefile
+++ b/examples_cute_sound/sdl_demo/Makefile
@@ -1,5 +1,5 @@
-OBJS = main.cpp
+OBJS = main.c
 OBJ_NAME = sdl_demo
 
 all : $(OBJS)
-	g++ -I. $(OBJS) -w -lSDL2 -o $(OBJ_NAME) -fpermissive
+	g++ -I. -I../.. $(OBJS) -w -lSDL2 -o $(OBJ_NAME) -fpermissive -DCUTE_SOUND_SDL_H="<SDL2/SDL.h>"

--- a/examples_cute_sound/sdl_demo/main.c
+++ b/examples_cute_sound/sdl_demo/main.c
@@ -1,14 +1,15 @@
 #define _CRT_SECURE_NO_WARNINGS
-#include <SDL2/SDL.h>
 
 #define STB_VORBIS_HEADER_ONLY
 #include "../stb_vorbis.c"
 
 #define CUTE_SOUND_IMPLEMENTATION
-#define CUTE_SOUND_FORCE_SDL
+#define CUTE_SOUND_PLATFORM_SDL
 #include <cute_sound.h>
 
+#ifndef CUTE_SOUND_PLATFORM_SDL
 #include <Windows.h>
+#endif
 
 #define CUTE_TIME_IMPLEMENTATION
 #include "cute_time.h"
@@ -16,7 +17,7 @@
 int main(int argc, char *args[])
 {
 	void* os_handle = NULL;
-#ifndef CUTE_SOUND_FORCE_SDL
+#ifndef CUTE_SOUND_PLATFORM_SDL
 	os_handle = GetConsoleWindow();
 #endif
 	cs_init(os_handle, 44100, 1024, NULL);


### PR DESCRIPTION
This change introduces three possible defines:

```
CUTE_SOUND_PLATFORM_WINDOWS
CUTE_SOUND_PLATFORM_APPLE
CUTE_SOUND_PLATFORM_SDL
```

This allows easily selecting the platform from your compiler definitions. Rather than specifying something like...

```
-DCUTE_SOUND_PLATFORM=2
```

... and having to figure out what "2" means, you can use...

```
-DCUTE_SOUND_PLATFORM_APPLE
```

The automatic platform detection is still in place, this just makes it easier to define within your compiler definitions. This is similar to `CUTE_SOUND_FORCE_SDL`, but can be applied to all platforms.
