### PR TITLE
Add EditorConfig to force tabs for whitespace

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+# EditorConfig
+# https://editorconfig.org
+
+root = true
+
+[*]
+indent_style = tab
+charset = utf-8
+end_of_line = lf
+indent_size = 4
+insert_final_newline = true
+trim_trailing_whitespace = true


### PR DESCRIPTION
I found there was some inconsistent whitespace usage across the files. Adding a [EditorConfig](https://editorconfig.org) definition file, and using the editorconfig extension in your favourite IDE, will ensure all whitespace takes on the same format. In this case, it'll apply tabs across files automatically for you.
