### PR TITLE
Fix raycasts ending right on the edge of an AABB

### DIFF
--- a/cute_c2.h
+++ b/cute_c2.h
@@ -1481,7 +1481,7 @@ static inline float c2SignedDistPointToPlane_OneDimensional(float p, float n, fl
 static inline float c2RayToPlane_OneDimensional(float da, float db)
 {
 	if (da < 0) return 0; // Ray started behind plane.
-	else if (da * db >= 0) return 1.0f; // Ray starts and ends on the same of the plane.
+	else if (da * db > 0) return 1.0f; // Ray starts and ends on the same of the plane.
 	else // Ray starts and ends on opposite sides of the plane (or directly on the plane).
 	{
 		float d = da - db;
@@ -1526,10 +1526,10 @@ int c2RaytoAABB(c2Ray A, c2AABB B, c2Raycast* out)
 	float t3 = c2RayToPlane_OneDimensional(da3, db3);
 
 	// Calculate hit predicate, no branching.
-	int hit0 = t0 < 1.0f;
-	int hit1 = t1 < 1.0f;
-	int hit2 = t2 < 1.0f;
-	int hit3 = t3 < 1.0f;
+	int hit0 = t0 <= 1.0f;
+	int hit1 = t1 <= 1.0f;
+	int hit2 = t2 <= 1.0f;
+	int hit3 = t3 <= 1.0f;
 	int hit = hit0 | hit1 | hit2 | hit3;
 
 	if (hit)


### PR DESCRIPTION
Alright, I'd be lying if said I fully understand what I am doing here, but this will not stop me :sweat_smile:

I am (very) slowly porting cute_c2 to Go for a project of mine, and as part of this effort I am writing unit tests for everything in the library. That's how I found the issue I describe in the commit message:

-----

The time (`t`) component of the raycast result was incorrect when the ray ended right on the edge of the AABB. For example:

```c
c2AABB aabb = {-2.0, -1.0, 3.0, 4.0};
c2Ray ray = {{-4.0, 2.0}, {1.0, 0.0}, 2.0};
c2Raycast out;

int res = c2RaytoAABB(ray, aabb, &out);
printf("t=%f\n", out.t);
```

This would print a `t` value of `0.0` when it should be `2.0`.

-----

**Very important:** I tested this just very briefly on the C library, so you may want to at least do any sanity checking you'd normally do.

Anyway, as far as I can tell, my proposed change makes sense -- but I also believe it works because it fixes these cases of the ray ending right on the edge of an AABB, and not breaking any of the numerous other test cases I have for raycasts to AABBs.

Worth mentioning: I think the change to `c2RayToPlane_OneDimensional()` isn't really necessary. I believe the end result will be same if you leave it out. *However*, I believe my proposed change makes the code match the comments regarding which branch deal with the "ray ending directly on the plane" case.

I hope you find this useful! Loving cute_c2! :smile: 