### PR TITLE
cute_aseprite: Add chunck 0x0004 support, and fix warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Various single-file cross-platform C/C++ headers implementing self-contained lib
 **[cute_c2](cute_c2.h)** | 2D collision detection routines on primitives, boolean results and/or manifold generation, shape cast/sweep test, raycasts | 1.10 | C/C++
 **[cute_net](cute_net.h)** | Networking library for games requiring an optional reliability layer over UDP with a baked in security scheme | 1.03 | C/C++
 **[cute_tiled](cute_tiled.h)** | Very efficient loader for Tiled maps exported to JSON format | 1.07 | C/C++
-**[cute_aseprite](cute_aseprite.h)** | Parses .ase/.aseprite files into a compact and convenient struct collection | 1.02 | C/C++
+**[cute_aseprite](cute_aseprite.h)** | Parses .ase/.aseprite files into a compact and convenient struct collection | 1.04 | C/C++
 **[cute_sound](cute_sound.h)** | Load/play/loop (with plugin)/pan WAV + OGG (stb_vorbis wrapper for OGG) in mono/stereo, high performance custom mixer, music + crossfade support | 2.04 | C/C++
 **[cute_math](cute_math.h)** | Professional level 3D vector math via SSE intrinsics | 1.02 | C++
 **[cute_png](cute_png.h)** | load/save PNG, texture atlas compiler, DEFLATE compliant decompressor | 1.05 | C/C++

--- a/cute_aseprite.h
+++ b/cute_aseprite.h
@@ -996,22 +996,22 @@ ase_t* cute_aseprite_load_from_memory(const void* memory, int size, void* mem_ct
 			switch (chunk_type) {
 			case 0x0004: // Old Palette chunk (used when there are no colors with alpha in the palette)
 			{
-				int nbPackets = (int)s_read_uint16(s);
-				for (int k = 0; k < nbPackets ; k++ ) {
-					uint16_t maxColor=0;
-					uint8_t skip = s_read_uint8(s);
-					uint16_t nbColors = s_read_uint8(s);
+				uint16_t nbPackets = s_read_uint16(s);
+				for (uint16_t k = 0; k < nbPackets; k++) {
+					uint16_t maxColor = 0;
+					uint16_t skip = (uint16_t)s_read_uint8(s);
+					uint16_t nbColors = (uint16_t)s_read_uint8(s);
 					if (nbColors == 0) nbColors = 256;
 
-					for (int l = 0; l < nbColors; l++) {
+					for (uint16_t l = 0; l < nbColors; l++) {
 						ase_palette_entry_t entry;
 						entry.color.r = s_read_uint8(s);
 						entry.color.g = s_read_uint8(s);
 						entry.color.b = s_read_uint8(s);
 						entry.color.a = 255;
 						entry.color_name = NULL;
-						ase->palette.entries[skip+l] = entry;
-						if (skip+l > maxColor) maxColor = skip+l;
+						ase->palette.entries[skip + l] = entry;
+						if (skip + l > maxColor) maxColor = skip + l;
 					}
 
 					ase->palette.entry_count = maxColor+1;


### PR DESCRIPTION
This builds from @redbug26 in https://github.com/RandyGaul/cute_headers/pull/376 to fix the type conversion warnings.
