### PR TITLE
Fix contact points on c2AABBtoAABBManifold

### DIFF
--- a/cute_c2.h
+++ b/cute_c2.h
@@ -1791,20 +1791,22 @@ void c2AABBtoAABBManifold(c2AABB A, c2AABB B, c2Manifold* m)
 	c2v n;
 	float depth;
 	c2v p;
+	float offset;
 
 	// x axis overlap is smaller
 	if (dx < dy)
 	{
 		depth = dx;
+		offset = c2Min(A.max.y, B.max.y) - mid_a.y;
 		if (d.x < 0)
 		{
 			n = c2V(-1.0f, 0);
-			p = c2Sub(mid_a, c2V(eA.x, 0));
+			p = c2Sub(mid_a, c2V(eA.x, -offset));
 		}
 		else
 		{
 			n = c2V(1.0f, 0);
-			p = c2Add(mid_a, c2V(eA.x, 0));
+			p = c2Add(mid_a, c2V(eA.x, offset));
 		}
 	}
 
@@ -1812,15 +1814,16 @@ void c2AABBtoAABBManifold(c2AABB A, c2AABB B, c2Manifold* m)
 	else
 	{
 		depth = dy;
+		offset = c2Min(A.max.x, B.max.x) - mid_a.x;
 		if (d.y < 0)
 		{
 			n = c2V(0, -1.0f);
-			p = c2Sub(mid_a, c2V(0, eA.y));
+			p = c2Sub(mid_a, c2V(-offset, eA.y));
 		}
 		else
 		{
 			n = c2V(0, 1.0f);
-			p = c2Add(mid_a, c2V(0, eA.y));
+			p = c2Add(mid_a, c2V(offset, eA.y));
 		}
 	}
 


### PR DESCRIPTION
Another attempt at fixing a little issue I found in cute_c2. This is working fine in my test cases, though I believe there must be a smarter way of implementing this. :sweat_smile: 

-----

Previously, we would in some cases return contact points that were not within the intersection of the two AABBs. For example,

```c
c2AABB a = {{-3.0, 2.0}, {1.001, 4.001}};
c2AABB b = {{1.0, 4.0}, {2.0, 6.0}};
c2Manifold m;
c2AABBtoAABBManifold(a, b, &m);
printf("p=(%f, %f)\n", m.contact_points[0].x, m.contact_points[0].y);
```

would print `p=(-0.999500, 4.001000)`.

This commit offsets the "other" coordinate of the contact points so that it lies within the intersection of the two AABBs. With the example above, it now prints `p=(1.001000, 4.001000)`.