### PR TITLE
Inflate polygons when passing `skin_factor > 0`

### DIFF
--- a/cute_c2.h
+++ b/cute_c2.h
@@ -1267,7 +1267,7 @@ c2Poly c2Dual(c2Poly poly, float skin_factor)
 	// dual = { a / d, b / d }
 	for (int i = 0; i < poly.count; ++i) {
 		c2v n = poly.norms[i];
-		float d = c2Dot(n, poly.verts[i]) - skin_factor;
+		float d = c2Dot(n, poly.verts[i]) + skin_factor;
 		if (d == 0) dual.verts[i] = c2V(0, 0);
 		else dual.verts[i] = c2Div(n, d);
 	}


### PR DESCRIPTION
Previously, the code for inflating polygons was behaving inconsistently with regards to the other shape types. Specifically, passing a positive `skin_factor` value would deflate a polygon, but inflate all the other shapes.

This commit makes the behavior consistent: `skin_factor > 0` implies in inflation for all shapes, including polygons.

Here's some sample code to test this change:

```c
	c2Circle circ = {{0.0, 0.0}, 1.0};
	c2Inflate(&circ, C2_TYPE_CIRCLE, 0.1);
	printf("Inflated circle: p=(%f, %f) r=%f\n", circ.p.x, circ.p.y, circ.r);

	c2Poly poly = {
		3,
		{{-1.0, -1.0}, {1.0, -1.0}, {0.0, 1.0}},
		{},
	};
	c2MakePoly(&poly);

	c2Inflate(&poly, C2_TYPE_POLY, 0.1);
	printf("Inflated polygon: verts=[(%f, %f), (%f, %f), (%f, %f)]\n", poly.verts[0].x, poly.verts[0].y, poly.verts[1].x, poly.verts[1].y,poly.verts[2].x, poly.verts[2].y);
```

Before this change we'd get an inflated circle (correct), but a deflated polygon (incorrect):

```
Inflated circle: p=(0.000000, 0.000000) r=1.100000
Inflated polygon: verts=[(0.000000, 0.776393), (-0.838197, -0.900000), (0.838197, -0.900000)]
```

After the change, both are inflated:

```
Inflated circle: p=(0.000000, 0.000000) r=1.100000
Inflated polygon: verts=[(0.000000, 1.223607), (-1.161803, -1.100000), (1.161803, -1.100000)]
```