### PR TITLE
Added strings.h include to resolve strncasecmp on some systems

### DIFF
--- a/cute_tiled.h
+++ b/cute_tiled.h
@@ -592,6 +592,7 @@ struct strpool_embedded_t
         #define STRPOOL_EMBEDDED_STRNICMP( s1, s2, len ) ( _strnicmp( s1, s2, len ) )
     #else
         #include <string.h>
+        #include <strings.h>
         #define STRPOOL_EMBEDDED_STRNICMP( s1, s2, len ) ( strncasecmp( s1, s2, len ) )
     #endif
 #endif


### PR DESCRIPTION
The header `strings.h` is the C standard compliant header for `strncasecmp`, however some implementations also declare it in `string.h` (which is why it complies on some distributions but not others). An include for `strings.h` has been added. The `string,h` include has been preserved in the event that there are some non-compliant implementations. We don't want to accidentally break things for some users, and there are minimal downsides to doing this.