### PR TITLE
[cute_png] moved free before usage

### DIFF
--- a/cute_png.h
+++ b/cute_png.h
@@ -1650,9 +1650,11 @@ cp_image_t cp_make_atlas(int atlas_width, int atlas_height, const cp_image_t* pn
 			cp_atlas_node_t* new_nodes = (cp_atlas_node_t*)CUTE_PNG_ALLOC(sizeof(cp_atlas_node_t) * new_capacity);
 			CUTE_PNG_CHECK(new_nodes, "out of mem");
 			CUTE_PNG_MEMCPY(new_nodes, nodes, sizeof(cp_atlas_node_t) * sp);
-			CUTE_PNG_FREE(nodes);
+
 			// best_fit became a dangling pointer, so relocate it
 			best_fit = new_nodes + (best_fit - nodes);
+			CUTE_PNG_FREE(nodes);
+
 			nodes = new_nodes;
 			atlas_node_capacity = new_capacity;
 		}


### PR DESCRIPTION
"nodes" is being freed and then immediately used. I dont think this is correct

compiler gives a warning for "use after free" without this change