### PR TITLE
cute_tiled: resolves #407 (object-layer color)

### DIFF
--- a/cute_tiled.h
+++ b/cute_tiled.h
@@ -2256,6 +2256,12 @@ cute_tiled_layer_t* cute_tiled_layers(cute_tiled_map_internal_t* m)
 			cute_tiled_read_int(m, &layer->id);
 		break;
 
+	case 4827327220562374952: // object-layer color
+		cute_tiled_expect(m, '"');
+		cute_tiled_read_hex_int(m, &layer->tintcolor);
+		cute_tiled_expect(m, '"');
+		break;
+
 		default:
 			CUTE_TILED_CHECK(0, "Unknown identifier found.");
 		}


### PR DESCRIPTION
Object-layers don't have tint, but they have another field for color. This reuses the tintcolor prop, that is used on tile-layers, since this serves the same purpose.

<img width="325" alt="Screenshot 2025-07-05 at 10 04 16 PM" src="https://github.com/user-attachments/assets/94b6eb43-8be8-4724-88a8-c96e83f67b17" />

related: #407 
