### PR TITLE
cute_tiled: fix bit shifting to use unsigned literal for alpha, fixes loading of background colors with alpha of 255

### DIFF
--- a/cute_tiled.h
+++ b/cute_tiled.h
@@ -1661,7 +1661,7 @@ static uint32_t cute_tiled_read_hex_int_internal(cute_tiled_map_internal_t* m, u
 
 	// When less than 6 characters, force an alpha channel of 255.
 	if (val_length <= 6) {
-		uint32_t alpha = 0xFF << 24;
+		uint32_t alpha = 0xFFu << 24;
 		*out = (*out & 0x00FFFFFF) | alpha;
 	}
 


### PR DESCRIPTION
I would like to prefix this PR with a disclaimer that I am not a C/C++ developer; I am using cute_tiled.h in a Zig project and came across this issue.

I had a problem where my program would crash when loading a Tiled map with the background color set to any color that has an alpha of 255. The error was as follows:

```
thread 86737 panic: left shift of 255 by 24 places cannot be represented in type 'int'
/home/elnu/.cache/zig/p/N-V-__8AAEmvJgEZ0CqpksmguOCp2n4BK3cpgIttoaLpYC49/cute_tiled.h:1664:25: 0x1174865 in cute_tiled_read_hex_int_internal (/home/elnu/Projects/shino/src/cute_tiled.c)
  uint32_t alpha = 0xFF << 24;
```

This is caused because the `0xFF` literal is being interpreted as a signed `int`, not a `uint32_t` despite the variable type. This PR explicitly makes the literal unsigned, fixing the issue:

```C
uint32_t alpha = 0xFF << 24;
```

This fixed the crash and reads out a correct ARGB color code for me.