### PR TITLE
Fix cute_tiled.h variable shadowing warnings on MSVC

### DIFF
--- a/cute_tiled.h
+++ b/cute_tiled.h
@@ -948,7 +948,6 @@ static void strpool_embedded_internal_expand_handles( strpool_embedded_t* pool )
 
 static char* strpool_embedded_internal_get_data_storage( strpool_embedded_t* pool, int size, int* alloc_size )
     {
-    char* data;
     int i;
     int offset;
     if( size < (int)sizeof( strpool_embedded_internal_free_block_t ) ) size = sizeof( strpool_embedded_internal_free_block_t );
@@ -999,7 +998,7 @@ static char* strpool_embedded_internal_get_data_storage( strpool_embedded_t* poo
 
     // Allocate a new block
     pool->current_block = strpool_embedded_internal_add_block( pool, size > pool->block_size ? size : pool->block_size );
-    data = pool->blocks[ pool->current_block ].tail;
+    char *data = pool->blocks[ pool->current_block ].tail;
     pool->blocks[ pool->current_block ].tail += size;
     *alloc_size = size;
     return data;
@@ -1013,8 +1012,6 @@ STRPOOL_EMBEDDED_U64 strpool_embedded_inject( strpool_embedded_t* pool, char con
     int base_count;
     int slot;
     int first_free;
-    int handle_index;
-    strpool_embedded_internal_entry_t* entry;
     int data_size;
     char* data;
     if( !string || length < 0 ) return 0;
@@ -1091,6 +1088,8 @@ STRPOOL_EMBEDDED_U64 strpool_embedded_inject( strpool_embedded_t* pool, char con
     pool->hash_table[ slot ].entry_index = pool->entry_count;
     ++pool->hash_table[ base_slot ].base_count;
 
+	int handle_index;
+    strpool_embedded_internal_entry_t* entry;
     if( pool->handle_count < pool->handle_capacity )
         {
         handle_index = pool->handle_count;


### PR DESCRIPTION
Hello!

I've been using the cute_tiled.h for a week or so and encountered multiple variable shadowing warnings in the strpool section when using MSVC (Visual Studio Community Edition 2022).

`.\cute_tiled.h(994): warning C4456: declaration of 'data' hides previous local declaration`
`.\cute_tiled.h(951): note: see declaration of 'data'`
`.\cute_tiled.h(1044): warning C4456: declaration of 'entry' hides previous local declaration`
`.\cute_tiled.h(1017): note: see declaration of 'entry'`
`.\cute_tiled.h(1052): warning C4456: declaration of 'handle_index' hides previous local declaration`
`.\cute_tiled.h(1016): note: see declaration of 'handle_index'`

Compiling the test_cute_tiled/main.cpp with /W4 emits three warnings about local variables being shadowed. Now, this is not really a problem but the solution is simple and negates the need to mess around with warning suppression. The pull request merely relocates the declaration of three local variables to the location they are first used at. As such, there should be hardly any difference in machine code besides possibly reducing the respective stack frames by a few bytes.

Thanks for the great library!

With kind regards,
Josh Lengel