### PR TITLE
cute_aseprite: continued support

### DIFF
--- a/cute_aseprite.h
+++ b/cute_aseprite.h
@@ -116,6 +116,8 @@ void cute_aseprite_free(ase_t* aseprite);
 #include <stdint.h>
 
 typedef struct ase_color_t ase_color_t;
+typedef struct ase_grayscale_t ase_grayscale_t;
+typedef struct ase_index_t ase_index_t;
 typedef struct ase_frame_t ase_frame_t;
 typedef struct ase_layer_t ase_layer_t;
 typedef struct ase_cel_t ase_cel_t;
@@ -131,6 +133,16 @@ typedef struct ase_fixed_t ase_fixed_t;
 struct ase_color_t
 {
 	uint8_t r, g, b, a;
+};
+
+struct ase_grayscale_t
+{
+	uint8_t v, a;
+};
+
+struct ase_index_t
+{
+	uint8_t i;
 };
 
 struct ase_fixed_t
@@ -200,7 +212,7 @@ struct ase_frame_t
 {
 	ase_t* ase;
 	int duration_milliseconds;
-	ase_color_t* pixels;
+	void* pixels;
 	int cel_count;
 	ase_cel_t cels[CUTE_ASEPRITE_MAX_LAYERS];
 };
@@ -910,31 +922,6 @@ static int s_max(int a, int b)
 	return a < b ? b : a;
 }
 
-static ase_color_t s_color(ase_t* ase, void* src, int index)
-{
-	ase_color_t result;
-	if (ase->mode == ASE_MODE_RGBA) {
-		result = ((ase_color_t*)src)[index];
-	} else if (ase->mode == ASE_MODE_GRAYSCALE) {
-		uint8_t saturation = ((uint8_t*)src)[index * 2];
-		uint8_t a = ((uint8_t*)src)[index * 2 + 1];
-		result.r = result.g = result.b = saturation;
-		result.a = a;
-	} else {
-		CUTE_ASEPRITE_ASSERT(ase->mode == ASE_MODE_INDEXED);
-		uint8_t palette_index = ((uint8_t*)src)[index];
-		if (palette_index == ase->transparent_palette_entry_index) {
-			result.r = 0;
-			result.g = 0;
-			result.b = 0;
-			result.a = 0;
-		} else {
-			result = ase->palette.entries[palette_index].color;
-		}
-	}
-	return result;
-}
-
 ase_t* cute_aseprite_load_from_memory(const void* memory, int size, void* mem_ctx)
 {
 	ase_t* ase = (ase_t*)CUTE_ASEPRITE_ALLOC(sizeof(ase_t), mem_ctx);
@@ -1239,9 +1226,18 @@ ase_t* cute_aseprite_load_from_memory(const void* memory, int size, void* mem_ct
 	// Blend all cel pixels into each of their respective frames, for convenience.
 	for (int i = 0; i < ase->frame_count; ++i) {
 		ase_frame_t* frame = ase->frames + i;
-		frame->pixels = (ase_color_t*)CUTE_ASEPRITE_ALLOC((int)(sizeof(ase_color_t)) * ase->w * ase->h, mem_ctx);
-		CUTE_ASEPRITE_MEMSET(frame->pixels, 0, sizeof(ase_color_t) * (size_t)ase->w * (size_t)ase->h);
-		ase_color_t* dst = frame->pixels;
+		int size;
+		if (ase->mode == ASE_MODE_RGBA) {
+			size = (int) (sizeof(ase_color_t)) * ase->w * ase->h;
+		} else if(ase->mode == ASE_MODE_GRAYSCALE) {
+			size = (int) (sizeof(ase_grayscale_t)) * ase->w * ase->h;
+		} else {
+			CUTE_ASEPRITE_ASSERT(ase->mode == ASE_MODE_INDEXED);
+			size = (int) (sizeof(ase_index_t)) * ase->w * ase->h;
+		}
+		frame->pixels = CUTE_ASEPRITE_ALLOC(size, mem_ctx);
+		CUTE_ASEPRITE_MEMSET(frame->pixels, 0, size);
+		void* dst = frame->pixels;
 		for (int j = 0; j < frame->cel_count; ++j) {
 			ase_cel_t* cel = frame->cels + j;
 			if (!(cel->layer->flags & ASE_LAYER_FLAGS_VISIBLE)) {
@@ -1277,11 +1273,19 @@ ase_t* cute_aseprite_load_from_memory(const void* memory, int size, void* mem_ct
 			int aw = ase->w;
 			for (int dx = dl, sx = cl; dx < dr; dx++, sx++) {
 				for (int dy = dt, sy = ct; dy < db; dy++, sy++) {
-					int dst_index = aw * dy + dx;
-					ase_color_t src_color = s_color(ase, src, cw * sy + sx);
-					ase_color_t dst_color = dst[dst_index];
-					ase_color_t result = s_blend(src_color, dst_color, opacity);
-					dst[dst_index] = result;
+					if (ase->mode == ASE_MODE_RGBA) {
+						ase_color_t *d = (ase_color_t *) dst;
+						ase_color_t src_color = ((ase_color_t *) src)[cw * sy + sx];
+						ase_color_t dst_color = d[dst_index];
+						ase_color_t result = s_blend(src_color, dst_color, opacity);
+						d[dst_index] = result;
+					 else if (ase->mode == ASE_MODE_GRAYSCALE) {
+						ase_grayscale_t *d = (ase_grayscale_t *) dst;
+						d[dst_index] = ((ase_grayscale_t *) src)[cw * sy + sx];
+					} else {
+						ase_index_t *d = (ase_index_t *) dst;
+						d[dst_index] = ((ase_index_t *) src)[cw * sy + sx];
+					}
 				}
 			}
 		}

--- a/cute_aseprite.h
+++ b/cute_aseprite.h
@@ -39,6 +39,9 @@
 		Special thanks to Richard Mitton for the initial implementation of the
 		zlib inflater.
 
+		Special thanks to Mathew Mariani (@mathewmariani) for the initial
+		implementation of tilesets and tilemaps.
+
 
 	Revision history:
 		1.00 (08/25/2020) initial release
@@ -47,7 +50,7 @@
 		                  ette index, can parse 1.3 files (no tileset support)
 		1.03 (11/27/2023) fixed slice pivot parse bug
   		1.04 (02/20/2024) chunck 0x0004 support
-		1.05 (02/20/2024) support indexed and grayscaled color modes, tileset,
+		1.05 (01/06/2025) support indexed and grayscaled color modes, tileset,
 		                  and tilemaps
 */
 


### PR DESCRIPTION
This pull requests adds support for color modes grayscale and indexed color modes, as well as, support for tilesets and tilemaps

`struct ase_frame_t` now has a field `void* pixels;` instead of a `ase_color_t* pixels` to reflect how the specs defined a pixel. We can cast to our desired color types (`struct ase_color_t`, `struct ase_grayscale_t`, and `struct ase_index`) as needed.

A pixel as described in the specs:
```
* `PIXEL`: One pixel, depending on the image pixel format:
  - **RGBA**: `BYTE[4]`, each pixel have 4 bytes in this order Red, Green, Blue, Alpha.
  - **Grayscale**: `BYTE[2]`, each pixel have 2 bytes in the order Value, Alpha.
  - **Indexed**: `BYTE`, each pixel uses 1 byte (the index).
```
  
Because blending is not supported for indexed color the blending step is skipped for routes where `ase->mode == ASE_MODE_INDEXED`.

I also added support chunk `0x2023`; tilesets and tilemaps through `struct ase_tileset_t` and `struct ase_cel_tilemap_t` respectively.

An example of loading and reading the pixels of a tileset:
```
ase_t *ase = cute_aseprite_load_from_file(path, NULL);
ase_tileset_t ase_tileset = ase->tileset;

// `struct ase_color_t`, `struct ase_grayscale_t`, or `struct ase_index`
const ase_color_t *pixels = (ase_color_t *) ase_tileset.pixels;
```

An example of loading and reading the tiles from a tilemap:
```
ase_t *ase = cute_aseprite_load_from_file(path, NULL);

for (int i = 0; i < ase->frame_count; ++i) {
  ase_frame_t *frame = ase->frames + i;
  for (int j = 0; j < frame->cel_count; ++j) {
    ase_cel_t *cel = frame->cels + j;
    if (cel->is_tilemap) {
      memcpy(tilemap, cel->tiles, size);
    }
  }
}

cute_aseprite_free(ase);
```