### PR TITLE
[cute_tiled] Add `cute_tiled_chunk_t` struct definition

### DIFF
--- a/cute_tiled.h
+++ b/cute_tiled.h
@@ -206,6 +206,7 @@ typedef struct cute_tiled_frame_t cute_tiled_frame_t;
 typedef struct cute_tiled_tile_descriptor_t cute_tiled_tile_descriptor_t;
 typedef struct cute_tiled_property_t cute_tiled_property_t;
 typedef union cute_tiled_string_t cute_tiled_string_t;
+typedef struct cute_tiled_chunk_t cute_tiled_chunk_t;
 
 /*!
  * To access a string, simply do: object->name.ptr; this union is needed


### PR DESCRIPTION
This fixes unknown type name `cute_tiled_chunk_t`.

```c
cute_tiled.h:344:9: error: unknown type name ‘cute_tiled_chunk_t’
  344 |         cute_tiled_chunk_t* next;            // Pointer to the next chunk, NULL if final chunk
      |         ^~~~~~~~~~~~~~~~~~