### PR TITLE
png: Fix compression flags when saving

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@
 example
 tests
 examples_cute_sound/sdl_demo/sdl_demo
+examples_cute_png/atlas.*
+examples_cute_png/main
 
 # vim
 *.swp

--- a/cute_png.h
+++ b/cute_png.h
@@ -1002,8 +1002,8 @@ static void cp_save_data(cp_save_png_data_t* s, cp_image_t* img, long dataPos, l
 	}
 
 	cp_begin_chunk(s, "IDAT", 0);
-	cp_put8(s, 0x08); // zlib compression method
-	cp_put8(s, 0x1D); // zlib compression flags
+	cp_put8(s, 0x78); // zlib CMF: deflate, 32K window (CINFO=7)
+	cp_put8(s, 0x9C); // zlib FLG: (0x78*256+0x9C)%31==0, default compression
 	cp_put_bits(s, 3, 3); // zlib last block + fixed dictionary
 
 	cp_lz77_compress(s, filtered, pos);


### PR DESCRIPTION
The saved atlas looks good after switching the compressions flags. Fixes #429



<img width="64" height="64" alt="atlas" src="https://github.com/user-attachments/assets/351e6b5e-0585-4f75-81cf-e9aef6cb5ba5" />

