### PR TITLE
Add LICENSE file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,37 @@
+------------------------------------------------------------------------------
+This software is available under 2 licenses - you may choose the one you like.
+------------------------------------------------------------------------------
+ALTERNATIVE A - zlib license
+Copyright (c) 2026 Randy Gaul https://randygaul.github.io/
+This software is provided 'as-is', without any express or implied warranty.
+In no event will the authors be held liable for any damages arising from
+the use of this software.
+Permission is granted to anyone to use this software for any purpose,
+including commercial applications, and to alter it and redistribute it
+freely, subject to the following restrictions:
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not
+     be misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+------------------------------------------------------------------------------
+ALTERNATIVE B - Public Domain (www.unlicense.org)
+This is free and unencumbered software released into the public domain.
+Anyone is free to copy, modify, publish, use, compile, sell, or distribute this
+software, either in source code form or as a compiled binary, for any purpose,
+commercial or non-commercial, and by any means.
+In jurisdictions that recognize copyright laws, the author or authors of this
+software dedicate any and all copyright interest in the software to the public
+domain. We make this dedication for the benefit of the public at large and to
+the detriment of our heirs and successors. We intend this dedication to be an
+overt act of relinquishment in perpetuity of all present and future rights to
+this software under copyright law.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+------------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

This PR adds a top-level LICENSE file for cute_headers.

The license text already exists in the source headers, but it is currently embedded at the end of individual header files. Having a standard top-level license file makes the licensing information easier to find for users, package managers, and automated tooling.

## Motivation

Some package managers expect a standalone license file and can handle it directly. For example, vcpkg provides vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE") to install a package license file in the expected location.

Without a top-level LICENSE file, package maintainers need to extract the license text from one of the headers manually. In the vcpkg cute-headers update, the portfile has to read cute_aseprite.h, locate the license marker, find the final comment terminator, and write the extracted text as the package copyright file. This is more fragile than simply installing a root license file.

Adding LICENSE avoids this kind of custom parsing logic and makes downstream packaging simpler and more reliable.

See also https://github.com/microsoft/vcpkg/pull/52293