### PR TITLE
cute_tiled: Fix failure to load when objects have a 'propertytype' JSON field.

### DIFF
--- a/cute_tiled.h
+++ b/cute_tiled.h
@@ -1928,6 +1928,11 @@ int cute_tiled_read_properties_internal(cute_tiled_map_internal_t* m, cute_tiled
 		// Read in the property name.
 		cute_tiled_skip_until_after(m, ':');
 		cute_tiled_intern_string(m, &prop.name);
+		
+		// If the field "propertytype" exists, skip it.
+		cute_tiled_skip_until_after(m, '"');
+		if (cute_tiled_next(m) == 'p')
+			cute_tiled_skip_until_after(m, ',');
 
 		// Read in the property type. The value type is deduced while parsing, this is only used for float because the JSON format omits decimals on round floats.
 		cute_tiled_skip_until_after(m, ':');


### PR DESCRIPTION
This PR prevents a JSON parsing error when loading a map where one or more Tiled objects contained in it make use of a custom enum type. The parsing error happens because from Tiled 1.8 onwards, a new field "propertytype" was added in their JSON specifications (which defines the enum name), which cute_tiled does not currently account for and fails when encountering it. The changes make it so that cute_tiled will skip this propertytype field during parsing and read a custom enum as a normal int or string.

Below is a copy of the map from my project where i tested this:
[rock_mnt.json](https://github.com/user-attachments/files/30474723/rock_mnt.json)
